### PR TITLE
added error handling of goimports process

### DIFF
--- a/GoImports.py
+++ b/GoImports.py
@@ -35,10 +35,14 @@ class GoImportsCommand(sublime_plugin.TextCommand):
 
         # Shove that content down goimports process's throat.
         process = subprocess.Popen([os.path.join(MY_PATH, "bin/goimports")],
-                stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.stdin.write(bytes(content, 'utf8'))
         process.stdin.close()
         process.wait()
-
-        # Put the result back.
-        self.view.replace(edit, selection, process.stdout.read().decode('utf8'))
+        
+        # Check and see if we got an error
+        error = process.stderr.read().decode('utf8')
+        if error:
+            print("error: " + error)
+        else:
+            self.view.replace(edit, selection, process.stdout.read().decode('utf8'))


### PR DESCRIPTION
Added a pipe for stdout from the process. We now check stderr first and print any errors we find instead of replacing text. If no error is found, we replace text (as before).

P.S. Not sure if I did this right. It's my first pull request and I'm newish to git so if I need to fix anything just let me know. Thanks